### PR TITLE
Cleanup and fixes based on the latest changes in `gap-docker-base`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,5 @@ RUN jupyter serverextension enable --py jupyterlab --user
 ENV PATH /home/gap/inst/gap-stable-4.9/pkg/JupyterKernel/bin:${PATH}
 ENV JUPYTER_GAP_EXECUTABLE /home/gap/inst/gap-stable-4.9/bin/gap.sh
 
-# Set up new user and home directory in environment.
-# Note that WORKDIR will not expand environment variables in docker versions < 1.3.1.
-# See docker issue 2637: https://github.com/docker/docker/issues/2637
-USER gap
-ENV HOME /home/gap
 ENV GAP_HOME /home/gap/inst/gap-stable-4.9
 ENV PATH ${GAP_HOME}/bin:${PATH}
-
-# Start at $HOME.
-WORKDIR /home/gap
-
-# Start from a BASH shell.
-CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN    sudo apt-get update -qq \
 RUN sudo pip3 install notebook jupyterlab_launcher jupyterlab traitlets ipython vdom
 
 RUN    cd /home/gap/inst/ \
-    && rm -rf gap4r8 \
     && wget -q https://github.com/gap-system/gap/archive/stable-4.9.zip \
     && unzip -q stable-4.9.zip \
     && rm stable-4.9.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,6 @@ FROM gapsystem/gap-docker-base
 
 MAINTAINER The GAP Group <support@gap-system.org>
 
-# Prerequirements
-RUN    sudo apt-get update -qq \
-    && sudo apt-get -qq install -y \
-                                   # for ANUPQ package to build in 32-bit mode
-                                   gcc-multilib \
-                                   # for ZeroMQ package
-                                   libzmq3-dev \
-                                   # for curlInterface
-                                   libcurl4-openssl-dev \
-                                   # for Jupyter
-                                   python3-pip
-
-RUN sudo pip3 install notebook jupyterlab_launcher jupyterlab traitlets ipython vdom
-
 RUN    mkdir /home/gap/inst/ \
     && cd /home/gap/inst/ \
     && wget -q https://github.com/gap-system/gap/archive/stable-4.9.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN    mkdir /home/gap/inst/ \
     && ./autogen.sh \
     && ./configure \
     && make \
+    && cp bin/gap.sh bin/gap \
     && mkdir pkg \
     && cd pkg \
     && wget -q https://www.gap-system.org/pub/gap/gap4pkgs/packages-stable-4.9.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,14 @@ RUN    mkdir /home/gap/inst/ \
     && tar xzf packages-stable-4.9.tar.gz \
     && rm packages-stable-4.9.tar.gz \
     && ../bin/BuildPackages.sh \
-    && cd JupyterKernel-* \
+    && test='JupyterKernel-*' \
+    && mv ${test} JupyterKernel \
+    && cd JupyterKernel \
     && python3 setup.py install --user
 
 RUN jupyter serverextension enable --py jupyterlab --user
 
-ENV PATH /home/gap/inst/gap-stable-4.9/pkg/JupyterKernel-0.99999/bin:${PATH}
+ENV PATH /home/gap/inst/gap-stable-4.9/pkg/JupyterKernel/bin:${PATH}
 ENV JUPYTER_GAP_EXECUTABLE /home/gap/inst/gap-stable-4.9/bin/gap.sh
 
 # Set up new user and home directory in environment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN    sudo apt-get update -qq \
 
 RUN sudo pip3 install notebook jupyterlab_launcher jupyterlab traitlets ipython vdom
 
-RUN    cd /home/gap/inst/ \
+RUN    mkdir /home/gap/inst/ \
+    && cd /home/gap/inst/ \
     && wget -q https://github.com/gap-system/gap/archive/stable-4.9.zip \
     && unzip -q stable-4.9.zip \
     && rm stable-4.9.zip \

--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
 # Docker container for GAP development version (stable-4.9 branch)
 
+DockerHub entry: https://registry.hub.docker.com/u/gapsystem/gap-docker-stable-4.9/
+
 This container provides the core GAP system build from the stable-4.9 branch
-of the GAP repository (https://github.com/gap-system) and GAP packages
+of the [GAP repository](https://github.com/gap-system) and GAP packages
 prepared for the next release of GAP made from that branch.
 
-Docker pull command to use this container:
+If you have installed [Docker](https://www.docker.com/), to use this
+container first you need to download it using
 
     docker pull gapsystem/gap-docker-stable-4.9
 
+(the same command is needed if you need to update the GAP container to get a
+new GAP release). After that, you can start it as follows:
+
+    docker run --rm -i -t gapsystem/gap-docker-stable-4.9
+
+Note that you may have to run `docker` with `sudo`, particularly if you are
+on Ubuntu.
+
+The location of GAP in the container is `/home/gap/inst/gap-stable-4.9`.
+
+For more details (e.g. on how to access GAP running in this Docker container from a
+Jupyter notebook in your browser) see the readme of https://github.com/gap-system/gap-docker
+and simply replace `gap-docker` by `gap-docker-stable-4.9`.


### PR DESCRIPTION
See commit messages for details.

Notes:
1. Running a Jupyter Notebook does neither work before nor after my changes.
2. This needs a rebuild of `gap-docker-base`!